### PR TITLE
FIxed model attribute injection with special characters

### DIFF
--- a/XGenerate/pom.xml
+++ b/XGenerate/pom.xml
@@ -70,6 +70,11 @@
 			<artifactId>vtd-xml</artifactId>
 			<version>${vtd-xml.version}</version>
 	    </dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>1.12.0</version>
+		</dependency>
 		<!-- Test dependencies. -->
 		<dependency>
 			<groupId>io.cucumber</groupId>

--- a/XGenerate/src/main/java/com/xbreeze/xgenerate/utils/XMLUtils.java
+++ b/XGenerate/src/main/java/com/xbreeze/xgenerate/utils/XMLUtils.java
@@ -42,6 +42,8 @@ import javax.xml.transform.ErrorListener;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import com.xbreeze.xgenerate.config.ConfigException;
 import com.xbreeze.xgenerate.generator.GeneratorException;
 import com.xbreeze.xgenerate.template.TemplatePreprocessor;
@@ -132,6 +134,7 @@ public class XMLUtils {
     	// Only inject attribute if it does not already exist
     	try {
     		int attributeValueIndex = nv.getAttrVal(attributeName);
+    		String encodedAttributeValue = StringEscapeUtils.escapeXml(attributeValue);
     		// If the attribute doesn't exist, create it.
 			if (attributeValueIndex == -1) {
 				// Take the element index and count 2 token per attribute (name and value) to get to the last attribute value index.
@@ -140,12 +143,12 @@ public class XMLUtils {
 				int lastAttributeValueEndIndex = (int)nv.getTokenOffset(lastAttributeValueIndex) + nv.getTokenLength(lastAttributeValueIndex) + 1;
 				logger.info(String.format("Appending attribute '%s' at %d", attributeName, lastAttributeValueEndIndex));
 				// Insert  the new attribute.
-				xm.insertBytesAt(lastAttributeValueEndIndex, String.format(" %s=\"%s\"", attributeName, attributeValue).getBytes());
+				xm.insertBytesAt(lastAttributeValueEndIndex, String.format(" %s=\"%s\"", attributeName, encodedAttributeValue).getBytes());
 			}
 			// If the attribute already exists, update it.
 			else {
 				try {
-					xm.updateToken(attributeValueIndex, attributeValue.getBytes());
+					xm.updateToken(attributeValueIndex, encodedAttributeValue.getBytes());
 				} catch (UnsupportedEncodingException e) {
 					throw new GeneratorException(String.format("Error while updating attribute value (%s)", attributeName), e);
 				}

--- a/XGenerate/src/test/resources/features/unit/config/model/Unit_Config_Model_ModelAttributeInjection.feature
+++ b/XGenerate/src/test/resources/features/unit/config/model/Unit_Config_Model_ModelAttributeInjection.feature
@@ -52,6 +52,7 @@ Feature: Unit_Config_Model_ModelAttributeInjection
       | filter value  | //entity[@name='B'] | Value      | simple                     |                 | simple          |                 |
       | simple XPath  | //entity            | XPath      | ./@name                    | A               | B               | C               |
       | filter XPath  | //entity[@name='B'] | XPath      | ./@name                    |                 | B               |                 |
+      | lower-case    | //entity            | XPath      | lower-case(@name)          | a               | b               | c               |
 
   @KnownIssue
   # KnownIssue: replace function is not implemented in vtd-xml
@@ -86,6 +87,47 @@ Feature: Unit_Config_Model_ModelAttributeInjection
     Examples: 
       | Scenario      | modelXPath          | targetType | targetValue                | expectedResultA | expectedResultB | expectedResultC |
       | replace XPath | //entity[@name='B'] | XPath      | replace(./@name, 'B', 'b') |                 | B               |                 |
+
+  Scenario Outline: Single <Scenario> quoted attribute injection
+    Given I have the following model:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <entities>
+        <entity name="&quot;A&quot;"/>
+        <entity name="&quot;B&quot;"/>
+        <entity name="&quot;C&quot;"/>
+      </entities>
+      """
+    Given the following config:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <XGenConfig>
+        <Model>
+          <ModelAttributeInjections>
+            <ModelAttributeInjection modelXPath="<modelXPath>" targetAttribute="type" target<targetType>="<targetValue>" />
+          </ModelAttributeInjections>
+        </Model>
+        <TextTemplate rootSectionName="Template">
+          <Output type="single_output" />
+        </TextTemplate>
+        <Binding>
+          <SectionModelBinding section="Template" modelXPath="/entities/entity" placeholderName="table" />
+        </Binding>
+      </XGenConfig>
+      """
+    When I run the generator
+    Then I expect 1 generation result
+    And an output named "Unit_Config_Model_ModelAttributeInjection.txt" with content:
+      """
+      "A" -> <expectedResultA>
+      "B" -> <expectedResultB>
+      "C" -> <expectedResultC>
+
+      """
+
+    Examples: 
+      | Scenario      | modelXPath          | targetType | targetValue                | expectedResultA | expectedResultB | expectedResultC |
+      | lower-case    | //entity            | XPath      | lower-case(@name)          | "a"             | "b"             | "c"             |
 
   Scenario: Multiple attribute injection
     Given the following config:


### PR DESCRIPTION
Added test scenario to reproduce error when injected attribute contains unsupported XML characters.
Added common text dependency for XML entity encoding.
Added XML encoding of attribute value during injection.